### PR TITLE
Fixed header rendering on mobile devices

### DIFF
--- a/src/sass/pages/_header.scss
+++ b/src/sass/pages/_header.scss
@@ -9,7 +9,6 @@
 	// Url must be relative to the entry file
 	background: url(../assets/header.jpg);
 	background-position: center;
-	background-attachment: fixed;
 	background-size: cover;
 
 	&__overlay {


### PR DESCRIPTION
background-attachment: fixed is not supported on iOS and Android.
I simply removed this line as the tradeoff is not worth it